### PR TITLE
remove peerDependecies from dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,11 +46,8 @@
   "dependencies": {
     "@babel/core": "^7.12.17",
     "@babel/preset-typescript": "^7.12.17",
-    "babel-preset-solid": "^0.24.2",
     "resolve.exports": "^1.0.2",
-    "solid-js": "^0.24.7",
-    "solid-refresh": "^0.0.1",
-    "vite": "^2.0.1"
+    "solid-refresh": "^0.0.1"
   },
   "devDependencies": {
     "@babel/plugin-transform-typescript": "^7.12.17",
@@ -59,9 +56,12 @@
     "@skypack/package-check": "^0.2.2",
     "@types/babel__core": "^7.1.12",
     "@types/node": "^14.14.31",
+    "babel-preset-solid": "^0.24.2",
     "prettier": "^2.2.1",
     "rollup": "^2.39.0",
     "rollup-plugin-cleaner": "^1.0.0",
-    "typescript": "^4.1.5"
+    "solid-js": "^0.24.7",
+    "typescript": "^4.1.5",
+    "vite": "^2.0.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,11 +1,8 @@
 dependencies:
   '@babel/core': 7.12.17
   '@babel/preset-typescript': 7.12.17_@babel+core@7.12.17
-  babel-preset-solid: 0.24.2_@babel+core@7.12.17
   resolve.exports: 1.0.2
-  solid-js: 0.24.7
   solid-refresh: 0.0.1_solid-js@0.24.7
-  vite: 2.0.1
 devDependencies:
   '@babel/plugin-transform-typescript': 7.12.17_@babel+core@7.12.17
   '@rollup/plugin-babel': 5.3.0_1d0ef3747f557ec43aa9273d615d9b9b
@@ -13,10 +10,13 @@ devDependencies:
   '@skypack/package-check': 0.2.2
   '@types/babel__core': 7.1.12
   '@types/node': 14.14.31
+  babel-preset-solid: 0.24.2_@babel+core@7.12.17
   prettier: 2.2.1
   rollup: 2.39.0
   rollup-plugin-cleaner: 1.0.0_rollup@2.39.0
+  solid-js: 0.24.7
   typescript: 4.1.5
+  vite: 2.0.1
 lockfileVersion: 5.2
 packages:
   /@babel/code-frame/7.12.13:
@@ -160,7 +160,7 @@ packages:
     dependencies:
       '@babel/core': 7.12.17
       '@babel/helper-plugin-utils': 7.12.13
-    dev: false
+    dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
@@ -332,7 +332,7 @@ packages:
       '@babel/helper-module-imports': 7.12.13
       '@babel/plugin-syntax-jsx': 7.12.13_@babel+core@7.12.17
       '@babel/types': 7.12.17
-    dev: false
+    dev: true
     peerDependencies:
       '@babel/core': '*'
     resolution:
@@ -340,7 +340,7 @@ packages:
   /babel-preset-solid/0.24.2_@babel+core@7.12.17:
     dependencies:
       babel-plugin-jsx-dom-expressions: 0.25.4_@babel+core@7.12.17
-    dev: false
+    dev: true
     peerDependencies:
       '@babel/core': '*'
     resolution:
@@ -380,7 +380,7 @@ packages:
     resolution:
       integrity: sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
   /colorette/1.2.1:
-    dev: false
+    dev: true
     resolution:
       integrity: sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw==
   /concat-map/0.0.1:
@@ -412,7 +412,7 @@ packages:
     resolution:
       integrity: sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==
   /esbuild/0.8.49:
-    dev: false
+    dev: true
     hasBin: true
     requiresBuild: true
     resolution:
@@ -431,6 +431,7 @@ packages:
     resolution:
       integrity: sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
   /fsevents/2.3.2:
+    dev: true
     engines:
       node: ^8.16.0 || ^10.6.0 || >=11.0.0
     optional: true
@@ -439,6 +440,7 @@ packages:
     resolution:
       integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
   /function-bind/1.1.1:
+    dev: true
     resolution:
       integrity: sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
   /gensync/1.0.0-beta.2:
@@ -471,6 +473,7 @@ packages:
   /has/1.0.3:
     dependencies:
       function-bind: 1.1.1
+    dev: true
     engines:
       node: '>= 0.4.0'
     resolution:
@@ -489,6 +492,7 @@ packages:
   /is-core-module/2.2.0:
     dependencies:
       has: 1.0.3
+    dev: true
     resolution:
       integrity: sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==
   /is-module/1.0.0:
@@ -536,7 +540,7 @@ packages:
     resolution:
       integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
   /nanoid/3.1.20:
-    dev: false
+    dev: true
     engines:
       node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1
     hasBin: true
@@ -555,6 +559,7 @@ packages:
     resolution:
       integrity: sha1-F0uSaHNVNP+8es5r9TpanhtcX18=
   /path-parse/1.0.6:
+    dev: true
     resolution:
       integrity: sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==
   /picomatch/2.2.2:
@@ -568,7 +573,7 @@ packages:
       colorette: 1.2.1
       nanoid: 3.1.20
       source-map: 0.6.1
-    dev: false
+    dev: true
     engines:
       node: ^10 || ^12 || >=14
     resolution:
@@ -590,6 +595,7 @@ packages:
     dependencies:
       is-core-module: 2.2.0
       path-parse: 1.0.6
+    dev: true
     resolution:
       integrity: sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==
   /rimraf/2.7.1:
@@ -611,6 +617,7 @@ packages:
     resolution:
       integrity: sha512-q+Zf9estkFwGede9QzmbkhKeuXzlliOvcICVNzBHAs5xYPPs1XLtfin5TMU2tC2EYjmfaF97saY9MnQM6Og4eA==
   /rollup/2.39.0:
+    dev: true
     engines:
       node: '>=10.0.0'
     hasBin: true
@@ -628,7 +635,7 @@ packages:
     resolution:
       integrity: sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
   /solid-js/0.24.7:
-    dev: false
+    dev: true
     resolution:
       integrity: sha512-Hi/Kvf3+e+664bBMG5NhZb+0jkWJHvMbWagCDH1AQMODFwoOZABBpUK1xfOhrtHEWMKpIz3fOzg5jOWwd/cdMA==
   /solid-refresh/0.0.1_solid-js@0.24.7:
@@ -645,7 +652,7 @@ packages:
     resolution:
       integrity: sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
   /source-map/0.6.1:
-    dev: false
+    dev: true
     engines:
       node: '>=0.10.0'
     resolution:
@@ -675,7 +682,7 @@ packages:
       postcss: 8.2.6
       resolve: 1.20.0
       rollup: 2.39.0
-    dev: false
+    dev: true
     engines:
       node: '>=12.0.0'
     hasBin: true


### PR DESCRIPTION
I think it doesn't makes sense to have `peerDependecies` as `dependencies`, and that's how other packages do it:

- https://github.com/rollup/plugins/blob/master/packages/babel/package.json
- https://github.com/babel/babel/blob/main/packages/babel-plugin-transform-typescript/package.json

Also `solid-refresh` may also need to be a peerDependency, and maybe `@babel/core` and `@babel/preset-typescript` too?