### PR TITLE
Resolve user alias config

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -28,10 +28,13 @@ export default function solidPlugin(options: Partial<Options> = {}): Plugin {
       // To fix that we convert user alias config to array.
       const userAlias = userConfig.resolve && userConfig.resolve.alias;
       const userAliasArray = !Array.isArray(userAlias)
-        ? Object.keys(userAlias).reduce((accum, aliasKey) => {
-            accum.push({ find: aliasKey, replacement: userAlias[aliasKey] });
-            return accum;
-          }, [])
+        ? Object.keys(userAlias).map(
+            (find) => ({
+              find,
+              replacement: userAlias[find],
+            }),
+            [],
+          )
         : [];
 
       const alias =


### PR DESCRIPTION
So there is an issue, with how alias config is merged by the vite. If the user used [object](https://vitejs.dev/config/#resolve-alias) format to set `alias`, vite will override it when merging the plugin config.

Not totally sure, if this should be the responsibility of the plugin or a vite itself.